### PR TITLE
feat: support universal rect inputs for polygon helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ console.log("Lines intersect:", intersects)
 | [`isPointInsidePolygon(point, polygon)`](./src/polygon.ts) | Determine if a point lies inside a polygon. |
 | [`areBoundsOverlappingPolygon(bounds, polygon)`](./src/polygon.ts) | Check whether bounds intersect or are contained by a polygon. |
 | [`areBoundsCompletelyInsidePolygon(bounds, polygon)`](./src/polygon.ts) | Determine if bounds are fully contained within a polygon. |
-| [`isRectOverlappingPolygon(rect, polygon)`](./src/polygon.ts) | Check whether a rectangle defined by `x`, `y`, `width`, and `height` overlaps a polygon. |
-| [`isRectCompletelyInsidePolygon(rect, polygon)`](./src/polygon.ts) | Determine if a rectangle is fully contained within a polygon. |
+| [`isRectOverlappingPolygon(rect, polygon)`](./src/polygon.ts) | Check whether a rectangle defined by a center point with dimensions or by bounds overlaps a polygon. |
+| [`isRectCompletelyInsidePolygon(rect, polygon)`](./src/polygon.ts) | Determine if a rectangle defined by a center point with dimensions or by bounds is fully contained within a polygon. |
 
-`rect` objects are expected to use the `{ x, y, width, height }` convention with `x` and `y` denoting the minimum corner.
+`rect` objects passed to these helpers can either specify a `center` along with `width` and `height` or provide `Bounds` directly.
 
 ## Contributing
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -16,3 +16,11 @@ export type Rect = {
   width: number
   height: number
 }
+
+export type UniversalRect =
+  | {
+      center: Point
+      width: number
+      height: number
+    }
+  | Bounds

--- a/src/polygon.ts
+++ b/src/polygon.ts
@@ -1,14 +1,23 @@
-import type { Bounds, Point, Rect } from "./common"
+import type { Bounds, Point, UniversalRect } from "./common"
 import { doSegmentsIntersect } from "./line-intersections"
 
 export type Polygon = readonly Point[]
 
-const rectToBounds = (rect: Rect): Bounds => ({
-  minX: rect.x,
-  minY: rect.y,
-  maxX: rect.x + rect.width,
-  maxY: rect.y + rect.height,
-})
+const universalRectToBounds = (rect: UniversalRect): Bounds => {
+  if ("minX" in rect) {
+    return rect
+  }
+
+  const halfWidth = rect.width / 2
+  const halfHeight = rect.height / 2
+
+  return {
+    minX: rect.center.x - halfWidth,
+    minY: rect.center.y - halfHeight,
+    maxX: rect.center.x + halfWidth,
+    maxY: rect.center.y + halfHeight,
+  }
+}
 
 const getBoundsCorners = (bounds: Bounds): Point[] => [
   { x: bounds.minX, y: bounds.minY },
@@ -146,11 +155,12 @@ export const areBoundsCompletelyInsidePolygon = (
 }
 
 export const isRectOverlappingPolygon = (
-  rect: Rect,
+  rect: UniversalRect,
   polygon: Polygon,
-): boolean => areBoundsOverlappingPolygon(rectToBounds(rect), polygon)
+): boolean => areBoundsOverlappingPolygon(universalRectToBounds(rect), polygon)
 
 export const isRectCompletelyInsidePolygon = (
-  rect: Rect,
+  rect: UniversalRect,
   polygon: Polygon,
-): boolean => areBoundsCompletelyInsidePolygon(rectToBounds(rect), polygon)
+): boolean =>
+  areBoundsCompletelyInsidePolygon(universalRectToBounds(rect), polygon)

--- a/tests/polygon.test.ts
+++ b/tests/polygon.test.ts
@@ -7,7 +7,7 @@ import {
   isRectOverlappingPolygon,
   type Bounds,
   type Point,
-  type Rect,
+  type UniversalRect,
 } from "../src"
 
 describe("polygon utilities", () => {
@@ -55,9 +55,17 @@ describe("polygon utilities", () => {
     )
   })
 
-  test("rect convenience wrappers use x/y/width/height format", () => {
-    const rectInside: Rect = { x: 1, y: 1, width: 2, height: 2 }
-    const rectCross: Rect = { x: 7, y: 7, width: 4, height: 4 }
+  test("rect convenience wrappers accept center/width/height format", () => {
+    const rectInside: UniversalRect = {
+      center: { x: 3, y: 3 },
+      width: 4,
+      height: 4,
+    }
+    const rectCross: UniversalRect = {
+      center: { x: 8.5, y: 8.5 },
+      width: 5,
+      height: 5,
+    }
 
     expect(isRectCompletelyInsidePolygon(rectInside, square)).toBe(true)
     expect(isRectOverlappingPolygon(rectInside, square)).toBe(true)


### PR DESCRIPTION
## Summary
- introduce a `UniversalRect` type to represent either center-based rectangles or bounds
- update polygon rectangle helpers to consume the new universal rectangle type and refresh the README
- adjust polygon tests to cover the new rectangle input format

## Testing
- bunx tsc --noEmit
- bun test tests/polygon.test.ts

------
https://chatgpt.com/codex/tasks/task_b_68df0ce75848832e8f6e5b7c3eb27b91